### PR TITLE
Add script to open `01_CesiumWorld.unity` at Editor launch

### DIFF
--- a/Assets/CesiumForUnitySamples/CesiumSamplesScene.cs
+++ b/Assets/CesiumForUnitySamples/CesiumSamplesScene.cs
@@ -18,11 +18,15 @@ using UnityEditor.SceneManagement;
 [InitializeOnLoad]
 static class CesiumSamplesSceneManager
 {
+    static readonly string samplesKey = "OpenedCesiumSamples";
+
     static CesiumSamplesSceneManager()
     {
         DisableTextMeshProIcons();
 
         EditorSceneManager.sceneOpened += ResetSceneViewCamera;
+        EditorApplication.update += OpenFirstSampleScene;
+        EditorApplication.quitting += RemoveSamplesKeyFromPlayerPrefs;
     }
 
     // There's no public API to disable component icons in the SceneView, which
@@ -59,6 +63,26 @@ static class CesiumSamplesSceneManager
                 }
             }
         }
+    }
+
+    // Unity will not open the first sample scene on its own, so this manually opens
+    // the sample scene when the Editor is first opened. The PlayerPref prevents
+    // the first scene from being re-opened whenever the user's code compiles.
+    static void OpenFirstSampleScene()
+    {
+        EditorApplication.update -= OpenFirstSampleScene;
+        if(PlayerPrefs.GetInt(samplesKey, -1) > 0)
+        {
+            return;
+        }
+
+        PlayerPrefs.SetInt(samplesKey, 1);
+        EditorSceneManager.OpenScene("Assets/Scenes/01_CesiumWorld.unity");
+    }
+
+    static void RemoveSamplesKeyFromPlayerPrefs()
+    {
+        PlayerPrefs.DeleteKey(samplesKey);
     }
 
     static void ResetSceneViewCamera(Scene scene, OpenSceneMode mode)
@@ -100,8 +124,6 @@ class CesiumSamplesScene : MonoBehaviour
         "(i.e. when \"1\" is pressed in the editor). This is used as an input " +
         "for SceneView.LookAtDirect.")]
     private float _lookAtSize = 0;
-
-    private readonly float _sceneViewFarClip = 1000000;
 
     [SerializeField]
     [Tooltip("The List of GameObjects that the scene should disable during play mode.")]
@@ -158,8 +180,6 @@ class CesiumSamplesScene : MonoBehaviour
     public void ResetSceneViewOnLoad()
     {
         ResetSceneView();
-        SceneView.lastActiveSceneView.cameraSettings.farClip = this._sceneViewFarClip;
-
         EditorApplication.update -= ResetSceneViewOnLoad;
     }
     #endif

--- a/Assets/Scenes/03_CesiumSanFrancisco.unity
+++ b/Assets/Scenes/03_CesiumSanFrancisco.unity
@@ -567,7 +567,7 @@ MonoBehaviour:
   _url: 
   _ionAssetID: 1
   _ionAccessToken: 
-  _maximumScreenSpaceError: 16
+  _maximumScreenSpaceError: 32
   _preloadAncestors: 1
   _preloadSiblings: 1
   _forbidHoles: 0
@@ -1020,8 +1020,8 @@ MonoBehaviour:
   _url: 
   _ionAssetID: 1415196
   _ionAccessToken: 
-  _maximumScreenSpaceError: 2
-  _preloadAncestors: 0
+  _maximumScreenSpaceError: 8
+  _preloadAncestors: 1
   _preloadSiblings: 1
   _forbidHoles: 0
   _maximumSimultaneousTileLoads: 20


### PR DESCRIPTION
This PR adds code that forces the Unity Editor to open on `01_CesiumWorld.unity` whenever the user opens the project. It would be more elegant to check if the Unity Editor was last opened to a Cesium samples scene, and if so, ignore opening the first scene. But I'm not sure what setting in the Unity Editor stores that so this will have to do for now.

I also changed the SSE in the San Francisco scene because I made it too small while taking screenshots.