### PR TITLE
Adjust light direction and shadow strength in SF scene.

### DIFF
--- a/Assets/Scenes/03_CesiumSanFrancisco.unity
+++ b/Assets/Scenes/03_CesiumSanFrancisco.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18278202, g: 0.22848725, b: 0.30703014, a: 1}
+  m_IndirectSpecularColor: {r: 0.17757809, g: 0.2223227, b: 0.304518, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -422,7 +422,7 @@ Light:
     m_Type: 2
     m_Resolution: -1
     m_CustomResolution: -1
-    m_Strength: 0.9
+    m_Strength: 0.2
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
@@ -470,14 +470,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 410087039}
-  m_LocalRotation: {x: 0.47981974, y: 0.20077702, z: -0.7878886, w: 0.32968658}
+  m_LocalRotation: {x: 0.46193978, y: 0.33141357, z: -0.19134171, w: 0.8001032}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 39.254, y: -53.654, z: -155.034}
+  m_LocalEulerAnglesHint: {x: 60, y: 45, z: 0}
 --- !u!114 &410087042
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
After we fixed the normals in CesiumGS/cesium-unity#133 and re-enabled shadows in CesiumGS/cesium-unity#131, the SF level started out looking at a dark blob of a Ferry Building:

![image](https://user-images.githubusercontent.com/924374/204511206-52ea495e-ccb5-4aff-96c0-cf743ffcfb41.png)

This PR adjusts the light direction and changes the shadow strength from 0.9 to 0.2 so it's a bit less terrible:

![image](https://user-images.githubusercontent.com/924374/204510821-cd653212-2a77-4a96-afef-2d577f6139e1.png)

I'm sure there are other ways to greatly improve it. If you turn around and look behind you, there are still dark blob buildings.