### PR TITLE
Set camera roll to zero

### DIFF
--- a/Assets/Scenes/01_CesiumWorld.unity
+++ b/Assets/Scenes/01_CesiumWorld.unity
@@ -695,14 +695,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1961636174}
-  m_LocalRotation: {x: 0.0004491039, y: -0.6610989, z: -0.0006780676, w: 0.7502984}
+  m_LocalRotation: {x: -0.00008514093, y: -0.66109586, z: -0.000075018266, w: 0.7503014}
   m_LocalPosition: {x: 104, y: -187, z: -1316}
   m_LocalScale: {x: 1, y: 1.0000004, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 819515654}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: -0.013, y: -82.767, z: -0.092}
+  m_LocalEulerAnglesHint: {x: -0.013, y: -82.767, z: 0}
 --- !u!114 &1961636176
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/01_CesiumWorld.unity
+++ b/Assets/Scenes/01_CesiumWorld.unity
@@ -824,16 +824,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _adjustOrientationForGlobeWhenMoving: 1
   _detectTransformChanges: 1
-  _positionAuthority: 3
+  _positionAuthority: 2
   _latitude: 37.792430588658114
   _longitude: -122.3768792710714
   _height: 125.69655911223805
   _ecefX: -2702426.6749069183
   _ecefY: -4262143.720191068
   _ecefZ: 3887340.310637725
-  _unityX: 104
-  _unityY: -187
-  _unityZ: -1316
+  _unityX: 104.00000000046569
+  _unityY: -186.99999999906868
+  _unityZ: -1315.9999999995343
 --- !u!114 &1961636179
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/02_CesiumMelbourne.unity
+++ b/Assets/Scenes/02_CesiumMelbourne.unity
@@ -671,14 +671,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1873770202}
-  m_LocalRotation: {x: -0.009777859, y: 0.21203023, z: -0.009969119, w: 0.9771634}
-  m_LocalPosition: {x: 245, y: 38, z: -1769}
+  m_LocalRotation: {x: 0.056999065, y: 0.24350385, z: -0.014337286, w: 0.9681175}
+  m_LocalPosition: {x: 252.2, y: 54.5, z: -1777.8}
   m_LocalScale: {x: 1, y: 1.0000004, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 819515654}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: -0.853, y: 24.495, z: -1.354}
+  m_LocalEulerAnglesHint: {x: 6.739, y: 28.237, z: 0}
 --- !u!114 &1873770204
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -801,15 +801,15 @@ MonoBehaviour:
   _adjustOrientationForGlobeWhenMoving: 1
   _detectTransformChanges: 1
   _positionAuthority: 3
-  _latitude: -37.825808457190305
-  _longitude: 144.95432075416468
-  _height: 178.5855806970893
-  _ecefX: -4129863.974103609
-  _ecefY: 2896671.4807112324
-  _ecefZ: -3890299.733376271
-  _unityX: 245
-  _unityY: 38
-  _unityZ: -1769
+  _latitude: -37.8258876960437
+  _longitude: 144.95440252868877
+  _height: 195.08831360608974
+  _ecefX: -4129874.364274235
+  _ecefY: 2896669.9743066328
+  _ecefZ: -3890316.801062552
+  _unityX: 252.1999969482422
+  _unityY: 54.5
+  _unityZ: -1777.800048828125
 --- !u!114 &1873770207
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/02_CesiumMelbourne.unity
+++ b/Assets/Scenes/02_CesiumMelbourne.unity
@@ -800,16 +800,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _adjustOrientationForGlobeWhenMoving: 1
   _detectTransformChanges: 1
-  _positionAuthority: 3
+  _positionAuthority: 2
   _latitude: -37.8258876960437
   _longitude: 144.95440252868877
   _height: 195.08831360608974
   _ecefX: -4129874.364274235
   _ecefY: 2896669.9743066328
   _ecefZ: -3890316.801062552
-  _unityX: 252.1999969482422
-  _unityY: 54.5
-  _unityZ: -1777.800048828125
+  _unityX: 252.1999969477765
+  _unityY: 54.50000000046566
+  _unityZ: -1777.8000488276593
 --- !u!114 &1873770207
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/04_CesiumSubScenes.unity
+++ b/Assets/Scenes/04_CesiumSubScenes.unity
@@ -585,14 +585,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485487348}
-  m_LocalRotation: {x: 0.004724692, y: -0.3484461, z: 0.0136240525, w: 0.9372179}
+  m_LocalRotation: {x: 0.008596969, y: -0.34836927, z: 0.0031952197, w: 0.93731254}
   m_LocalPosition: {x: 4.7, y: 4.656613e-10, z: -3.55}
   m_LocalScale: {x: 0.99999994, y: 1.0000004, z: 0.9999998}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 819515654}
   m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: -42.162, z: 0}
+  m_LocalEulerAnglesHint: {x: 1.051, y: -40.777, z: 0}
 --- !u!114 &485487350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -714,13 +714,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _adjustOrientationForGlobeWhenMoving: 1
   _detectTransformChanges: 1
-  _positionAuthority: 2
+  _positionAuthority: 3
   _latitude: 39.74343003560012
   _longitude: -104.98883718102722
-  _height: 1798.6794490305529
-  _ecefX: -1270486.0709356265
-  _ecefY: -4745216.377065663
-  _ecefZ: 4057271.9274624404
+  _height: 1798.6794490318864
+  _ecefX: -1270486.0709356267
+  _ecefY: -4745216.377065664
+  _ecefZ: 4057271.927462441
   _unityX: 4.699999809265137
   _unityY: 0.0000000004656612873077393
   _unityZ: -3.549999952316284

--- a/Assets/Scenes/04_CesiumSubScenes.unity
+++ b/Assets/Scenes/04_CesiumSubScenes.unity
@@ -586,7 +586,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485487348}
   m_LocalRotation: {x: 0.008596969, y: -0.34836927, z: 0.0031952197, w: 0.93731254}
-  m_LocalPosition: {x: 4.7, y: 4.656613e-10, z: -3.55}
+  m_LocalPosition: {x: 4.7, y: 0.0000000013969839, z: -3.55}
   m_LocalScale: {x: 0.99999994, y: 1.0000004, z: 0.9999998}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -714,7 +714,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _adjustOrientationForGlobeWhenMoving: 1
   _detectTransformChanges: 1
-  _positionAuthority: 3
+  _positionAuthority: 2
   _latitude: 39.74343003560012
   _longitude: -104.98883718102722
   _height: 1798.6794490318864
@@ -722,8 +722,8 @@ MonoBehaviour:
   _ecefY: -4745216.377065664
   _ecefZ: 4057271.927462441
   _unityX: 4.699999809265137
-  _unityY: 0.0000000004656612873077393
-  _unityZ: -3.549999952316284
+  _unityY: 0.0000000013969838619232178
+  _unityZ: -3.5499999527819455
 --- !u!114 &485487353
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/05_CesiumMetadata.unity
+++ b/Assets/Scenes/05_CesiumMetadata.unity
@@ -867,7 +867,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _adjustOrientationForGlobeWhenMoving: 1
   _detectTransformChanges: 1
-  _positionAuthority: 3
+  _positionAuthority: 2
   _latitude: 40.710295999902705
   _longitude: -74.007328
   _height: 348.05268076377445
@@ -875,7 +875,7 @@ MonoBehaviour:
   _ecefY: -4654503.72848886
   _ecefZ: 4138316.47659845
   _unityX: 0
-  _unityY: -51.79999923706055
+  _unityY: -51.799999236129224
   _unityZ: 0
 --- !u!114 &1574618767
 MonoBehaviour:


### PR DESCRIPTION
The transforms of the `DynamicCamera` had non-zero rotations around the Z-axis, meaning they were slightly askew. This PR sets those values to zero.