### PR TITLE
Fix typos in legacy input system code

### DIFF
--- a/Assets/CesiumForUnitySamples/Scripts/CesiumSamplesMetadataPicking.cs
+++ b/Assets/CesiumForUnitySamples/Scripts/CesiumSamplesMetadataPicking.cs
@@ -39,7 +39,7 @@ public class CesiumSamplesMetadataPicking : MonoBehaviour
         {
             getMetadata = Gamepad.current.rightShoulder.isPressed;
         }
-        #elif ENABLE_LEGACY_INPUT_MANAGER
+        #else
         bool getMetadata = Input.GetMouseButtonDown(0);
         #endif
 

--- a/Assets/CesiumForUnitySamples/Scripts/CesiumSamplesSubSceneManager.cs
+++ b/Assets/CesiumForUnitySamples/Scripts/CesiumSamplesSubSceneManager.cs
@@ -63,7 +63,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
     {
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit1Key.isPressed || Keyboard.current.numpad1Key.isPressed;
-        #elif ENABLE_LEGACY_INPUT_MANAGER
+        #else
         return Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1);
         #endif
     }
@@ -72,7 +72,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
     {
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit2Key.isPressed || Keyboard.current.numpad2Key.isPressed;
-        #elif ENABLE_LEGACY_INPUT_MANAGER
+        #else
         return Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2);
         #endif
     }
@@ -80,7 +80,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
     {
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit3Key.isPressed || Keyboard.current.numpad3Key.isPressed;
-        #elif ENABLE_LEGACY_INPUT_MANAGER
+        #else
         return Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3);
         #endif
     }
@@ -88,7 +88,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
     {
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit4Key.isPressed || Keyboard.current.numpad4Key.isPressed;
-        #elif ENABLE_LEGACY_INPUT_MANAGER
+        #else
         return Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4);
         #endif
     }

--- a/Assets/CesiumForUnitySamples/Scripts/CesiumSamplesSubSceneManager.cs
+++ b/Assets/CesiumForUnitySamples/Scripts/CesiumSamplesSubSceneManager.cs
@@ -64,7 +64,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit1Key.isPressed || Keyboard.current.numpad1Key.isPressed;
         #elif ENABLE_LEGACY_INPUT_MANAGER
-        return Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
+        return Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1);
         #endif
     }
 
@@ -73,7 +73,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit2Key.isPressed || Keyboard.current.numpad2Key.isPressed;
         #elif ENABLE_LEGACY_INPUT_MANAGER
-        return Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
+        return Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2);
         #endif
     }
     static bool GetKey3Down()
@@ -81,7 +81,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit3Key.isPressed || Keyboard.current.numpad3Key.isPressed;
         #elif ENABLE_LEGACY_INPUT_MANAGER
-        return Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3))
+        return Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3);
         #endif
     }
     static bool GetKey4Down()
@@ -89,7 +89,7 @@ public class CesiumSamplesSubSceneManager : MonoBehaviour
         #if ENABLE_INPUT_SYSTEM
         return Keyboard.current.digit4Key.isPressed || Keyboard.current.numpad4Key.isPressed;
         #elif ENABLE_LEGACY_INPUT_MANAGER
-        return Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4))
+        return Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4);
         #endif
     }
 


### PR DESCRIPTION
While testing https://github.com/CesiumGS/cesium-unity/pull/272 I got compilation errors due to typos in the legacy input code in `CesiumSamplesSubSceneManager`. This fixes those typos. It also seems like the `#define` I was checking doesn't exist when only the legacy input system is used, so I removed the check.