### PR TITLE
Remove references to Cesium for Unity

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,17 +1,5 @@
 {
   "dependencies": {
-    "com.cesium.unity": {
-      "version": "1.14.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.mathematics": "1.2.0",
-        "com.unity.test-framework": "1.1.31",
-        "com.unity.shadergraph": "12.1.6",
-        "com.unity.inputsystem": "1.4.2"
-      },
-      "url": "https://unity.pkg.cesium.com"
-    },
     "com.unity.ai.navigation": {
       "version": "1.1.5",
       "depth": 0,

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -26,15 +26,7 @@ MonoBehaviour:
     m_IsDefault: 1
     m_Capabilities: 7
     m_ConfigSource: 0
-  - m_Id: scoped:project:Cesium
-    m_Name: Cesium
-    m_Url: https://unity.pkg.cesium.com
-    m_Scopes:
-    - com.cesium.unity
-    m_IsDefault: 0
-    m_Capabilities: 0
-    m_ConfigSource: 4
-  m_UserSelectedRegistryName: Cesium
+  m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0


### PR DESCRIPTION
We have historically excluded `com.cesium.unity` from the `packages-lock` file. For one, the `json` is updated differently depending on whether the package is embedded in the files (e.g., cloning Cesium for Unity). For two, it gives us one less place to update the version when we do a new release.

`PackageManagerSettings.asset` has also been changed for this. I confirmed that opening the project will make these autofill to their correct states, but feel free to test locally if it helps with sanity